### PR TITLE
Fix multi-display timed login

### DIFF
--- a/daemon/mdm.c
+++ b/daemon/mdm.c
@@ -256,10 +256,9 @@ mdm_start_first_unborn_local (int delay)
 			 * before starting */
 			d->sleep_before_run = delay;
 
-			/* only the first static display has
+			/* all static displays have
 			 * timed login going on */
-			if (mdm_first_login)
-				d->timed_login_ok = TRUE;
+			d->timed_login_ok = TRUE;
 
 			svr = mdm_server_resolve (d);
 


### PR DESCRIPTION
This patch fixes a known bug in former GDM for multiseat setups, where only the first display has automatic/timed login enabled:

https://bugzilla.gnome.org/show_bug.cgi?id=336174#c13

With this patch, we can set in mdm.conf e.g.

[daemon]
TimedLoginEnable=true
TimedLogin=/usr/local/bin/getloginuser|
TimedLoginDelay=30

where "getloginuser" is a script that returns a valid username depending on value of environment variable DISPLAY, and all displays have timed login enabled.

However, at least in my local test, this patch does NOT fix the corresponding automatic login bug, i.e., if I put

[daemon]
AutomaticLoginEnable=true
AutomaticLogin=/usr/local/bin/getloginuser|

in mdm.conf, only the first display would get autologin enabled, even with this patch applied.
