### PR TITLE
add build-dep for webkit

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -31,7 +31,8 @@ Build-Depends: libpam0g-dev,
                quilt,
                zenity,
                libpopt-dev,
-               xserver-xorg
+               xserver-xorg,
+               libwebkitgtk-dev
 Standards-Version: 3.9.0
 
 Package: mdm


### PR DESCRIPTION
`libwebkitgtk-dev` satisfies the dependency, but I wonder if it's overkill.

[raring](http://packages.ubuntu.com/raring/libwebkitgtk-dev) -- [wheezy](http://packages.debian.org/wheezy/libwebkitgtk-dev)
