### PR TITLE
Add systemd service file and build hooks for mdm.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,8 @@ Build-Depends: libpam0g-dev,
                xserver-xorg,
                libwebkitgtk-dev,
                gnome-common,
-               libxml2-utils
+               libxml2-utils,
+               dh-systemd (>= 1.5)
 Standards-Version: 3.9.0
 
 Package: mdm

--- a/debian/mdm.service
+++ b/debian/mdm.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Linux Mint Display Manager
+Documentation=man:mdm(1)
+Conflicts=getty@tty1.service
+After=systemd-user-sessions.service getty@tty1.service
+
+[Service]
+ExecStart=/usr/sbin/mdm --nodaemon
+ExecReload=/usr/sbin/mdm-restart
+ExecStop=/usr/sbin/mdm-stop
+StandardOutput=journal
+Restart=always
+RestartSec=1s
+TimeoutStopSec=5s
+IgnoreSIGPIPE=no
+
+[Install]
+WantedBy=graphical.target
+Alias=display-manager.service
+

--- a/debian/rules
+++ b/debian/rules
@@ -82,7 +82,9 @@ binary-arch: build install
 	dh_installpam -a
 	# additional PAM file to install
 	dh_installpam -pmdm --name=mdm-autologin
+	dh_systemd_enable
 	dh_installinit -a --noscripts
+	dh_systemd_start
 	dh_installman -a
 	dh_installchangelogs -a ChangeLog
 	dh_strip -a


### PR DESCRIPTION
This commit adds the basic systemd support needed to ensure mdm will correctly be started on systems using systemd rather then sysV init as indicated by Debian packaging guidelines.

It is based on issue #32, tweaked with the correct alias and starting parameters. I've tested it working fine with Utopic and Mint packages running pure systemd.
