### PR TITLE
Save theme directory instead of theme name in mdm.conf.

### DIFF
--- a/gui/mdmsetup.c
+++ b/gui/mdmsetup.c
@@ -1500,13 +1500,13 @@ selected_html_toggled (GtkCellRendererToggle *cell, char *path_str, gpointer dat
 			break;
 		case THEME_TYPE_HTML:
 			mdm_setup_config_set_string (MDM_KEY_GREETER, g_strdup (LIBEXECDIR "/mdmwebkit"));
-			gtk_tree_model_get_value (model, &selected_iter, THEME_COLUMN_NAME, &value);
+			gtk_tree_model_get_value (model, &selected_iter, THEME_COLUMN_DIR, &value);
 			mdm_setup_config_set_string (MDM_KEY_HTML_THEME, g_value_get_string (&value));
 			g_value_unset (&value);
 			break;
 		case THEME_TYPE_GDM:
 			mdm_setup_config_set_string (MDM_KEY_GREETER, g_strdup (LIBEXECDIR "/mdmgreeter"));
-			gtk_tree_model_get_value (model, &selected_iter, THEME_COLUMN_NAME, &value);
+			gtk_tree_model_get_value (model, &selected_iter, THEME_COLUMN_DIR, &value);
 			mdm_setup_config_set_string (MDM_KEY_GRAPHICAL_THEME, g_value_get_string (&value));
 			g_value_unset (&value);
 			break;


### PR DESCRIPTION
This fixes the loading errors in the cases when the theme's dir
isn't the same as its name (see Brit Waves, Linux Mint themes)
or, even worse, the theme name is localized while its dir isn't,
obviously (see Circles theme).

Fixes https://bugs.launchpad.net/bugs/1392787
