### PR TITLE
fix untranslatable-debconf-templates error in mdm.templates

### DIFF
--- a/debian/mdm.templates
+++ b/debian/mdm.templates
@@ -6,7 +6,7 @@ Description: for internal use only
 Template: shared/default-x-display-manager
 Type: select
 Choices: ${choices}
-Description: Default display manager:
+Description.UTF-8: Default display manager:
  A display manager is a program that provides graphical login capabilities for
  the X Window System.
  .


### PR DESCRIPTION
Fix for these Lintian errors:
```
E: mdm source: untranslatable-debconf-templates mdm.templates: 9
E: mdm source: not-using-po-debconf
```
