### PR TITLE
Move XDG_DATA_DIR append to *after* run-parts

### DIFF
--- a/debian/Xsession
+++ b/debian/Xsession
@@ -110,15 +110,6 @@ test -f "$HOME/.profile" && . "$HOME/.profile"
 test -f /etc/xprofile && . /etc/xprofile
 test -f "$HOME/.xprofile" && . "$HOME/.xprofile"
 
-# Install MDM desktop files to a non-default desktop file
-# location (/usr/share/mdm/applications) and MDM appends
-# this directory to the end of the XDG_DATA_DIR environment
-# variable.  This way, MDM menu choices never appear if
-# using a different display manager.
-
-XDG_DATA_DIRS="$XDG_DATA_DIRS":"/usr/share/mdm/"
-export XDG_DATA_DIRS
-
 # Translation stuff
 if [ -x "/usr/lib/mdm/mdmtranslate" ] ; then
   mdmtranslate="/usr/lib/mdm/mdmtranslate"
@@ -204,6 +195,15 @@ if [ -n "$SESSIONFILES" ]; then
     . $SESSIONFILE
   done
 fi
+
+# Install MDM desktop files to a non-default desktop file
+# location (/usr/share/mdm/applications) and MDM appends
+# this directory to the end of the XDG_DATA_DIR environment
+# variable.  This way, MDM menu choices never appear if
+# using a different display manager.
+
+XDG_DATA_DIRS="$XDG_DATA_DIRS":"/usr/share/mdm/"
+export XDG_DATA_DIRS
 
 echo "$0: Executing $command failed, will try to run x-terminal-emulator"
 


### PR DESCRIPTION
/etc/X11/Xsession.d/60x11-common_xdg_path sets the default XDG_DATA_DIR
based on some hard-coded paths, and includes an override for setting the DE
path if it's Gnome.

The old placement broke this and /etc/X11/Xsession.d/55cinnamon-session_gnomerc
which tries to do the same thing. Moving the append to after run-parts fixes
this problem, and removes ambiguity.

This problem was introduced in commit 9543455f420d2cada8e021618c535620d08cd6d8.

I can confirm from my own system (which was broken when the relevant nightlies hit) that
this patch fixes the problem. It manifests as the session dying when started via `mdm` but not
via a logged in console session.
